### PR TITLE
Don't set video backgroundColor on Android API Version 24 and above

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const styles = StyleSheet.create({
   playArrow: {
     color: 'white',
   },
-  video: Platform.Version === 25 ? {} : {
+  video: Platform.Version >= 24 ? {} : {
     backgroundColor: 'black',
   },
   controls: {


### PR DESCRIPTION
Don't set video backgroundColor on Android API Version 24 and above. Solves the following issue:

react-native-community/react-native-video#649